### PR TITLE
Maintenance - Update actions/checkout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           coverage: pcov
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 


### PR DESCRIPTION
### Issue
Getting warning `Node.js 12 actions are deprecated` from actions log:

https://github.com/hobbii/tap-api/actions/runs/3417339628

### Proposal:
Set actions/checkout to v3 (node 16)

### Notes
See
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.com/hobbii/opencart/pull/4767